### PR TITLE
Ensure that ANDROID_HOME is set

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,5 +19,5 @@ jobs:
         ./gradlew assembleDebug
     - name: Run tests
       run: |
-        source scripts/android-setup.sh && installsdk 'cmake;3.10.2.4988404'
+        source scripts/android-setup.sh && installAndroidSDK && installsdk 'cmake;3.10.2.4988404'
         scripts/run-host-tests.sh


### PR DESCRIPTION
Summary:
Ugh, because GitHub doesn't support stacked diffs, I got all sorts of merge conflicts and this line fell out.

Test Plan:
Green tick mark: https://github.com/facebookincubator/fbjni/pull/9/checks?check_run_id=238707039