### PR TITLE
Remove unnecessary ::javaobject in ref types

### DIFF
--- a/cxx/fbjni/Context.h
+++ b/cxx/fbjni/Context.h
@@ -27,12 +27,12 @@ class AContext : public JavaClass<AContext> {
   static constexpr const char* kJavaDescriptor = "Landroid/content/Context;";
 
   // Define a method that calls into the represented Java class
-  local_ref<JFile::javaobject> getCacheDir() {
+  local_ref<JFile> getCacheDir() {
     static const auto method = getClass()->getMethod<JFile::javaobject()>("getCacheDir");
     return method(self());
   }
 
-  local_ref<JFile::javaobject> getFilesDir() {
+  local_ref<JFile> getFilesDir() {
     static const auto method = getClass()->getMethod<JFile::javaobject()>("getFilesDir");
     return method(self());
   }

--- a/cxx/fbjni/detail/CoreClasses.h
+++ b/cxx/fbjni/detail/CoreClasses.h
@@ -75,8 +75,8 @@ bool isSameObject(alias_ref<JObject> lhs, alias_ref<JObject> rhs) noexcept;
 //   constexpr static auto kJavaDescriptor = "Lcom/example/package/MyClass;";
 // };
 //
-// Then, an alias_ref<MyClass::javaobject> will be backed by an instance of
-// MyClass. JavaClass provides a convenient way to add functionality to these
+// Then, an alias_ref<MyClass> will be backed by an instance of MyClass.
+// JavaClass provides a convenient way to add functionality to these
 // smart references.
 //
 // For example:
@@ -197,7 +197,7 @@ struct JTypeFor<T, Base, void> {
 //   static constexpr auto kJavaDescriptor = "Lcom/example/package/Foo;";
 // };
 // fbjni can determine the java type/method signatures for Foo::javaobject and
-// smart refs (like alias_ref<Foo::javaobject>) will hold an instance of Foo
+// smart refs (like alias_ref<Foo>) will hold an instance of Foo
 // and provide access to it through the -> and * operators.
 //
 // The "Base" template argument can be used to specify the JavaClass superclass

--- a/cxx/fbjni/detail/Iterator-inl.h
+++ b/cxx/fbjni/detail/Iterator-inl.h
@@ -120,7 +120,7 @@ class Iterator {
     return ret;
   }
 
-  global_ref<typename T::javaobject> helper_;
+  global_ref<T> helper_;
   // set to -1 at end
   std::ptrdiff_t i_;
   value_type entry_;

--- a/cxx/fbjni/detail/Iterator.h
+++ b/cxx/fbjni/detail/Iterator.h
@@ -27,9 +27,9 @@ namespace jni {
  * underlying collection.  The class has a template parameter for the element
  * type, which defaults to jobject.  For example:
  *
- * alias_ref<JIterator<jstring>::javaobject> my_iter = ...;
+ * alias_ref<JIterator<jstring>> my_iter = ...;
  *
- * In the simplest case, it can be used just as alias_ref<JIterator<>::javaobject>,
+ * In the simplest case, it can be used just as alias_ref<JIterator<>>,
  * for example in a method declaration.
  */
 template <typename E = jobject>
@@ -114,9 +114,9 @@ struct JSet : JavaClass<JSet<E>, JCollection<E>> {
  * C++-style iteration over the Java Map.  The class has template parameters
  * for the key and value types, which default to jobject.  For example:
  *
- * alias_ref<JMap<jstring, MyJClass::javaobject>::javaobject> my_map = ...;
+ * alias_ref<JMap<jstring, MyJClass>> my_map = ...;
  *
- * In the simplest case, it can be used just as alias_ref<JMap<>::javaobject>,
+ * In the simplest case, it can be used just as alias_ref<JMap<>>,
  * for example in a method declaration.
  */
 template <typename K = jobject, typename V = jobject>

--- a/cxx/fbjni/detail/Meta-inl.h
+++ b/cxx/fbjni/detail/Meta-inl.h
@@ -48,7 +48,7 @@ struct ArgsArraySetter;
 
 template <int idx, typename Arg, typename... Args>
 struct ArgsArraySetter<idx, Arg, Args...> {
-  static void set(alias_ref<JArrayClass<jobject>::javaobject> array, Arg arg0, Args... args) {
+  static void set(alias_ref<JArrayClass<jobject>> array, Arg arg0, Args... args) {
     // TODO(xxxxxxxx): Use Convert<Args>... to do conversions like the fast path.
     (*array)[idx] = autobox(arg0);
     ArgsArraySetter<idx + 1, Args...>::set(array, args...);
@@ -57,13 +57,13 @@ struct ArgsArraySetter<idx, Arg, Args...> {
 
 template <int idx>
 struct ArgsArraySetter<idx> {
-  static void set(alias_ref<JArrayClass<jobject>::javaobject> array) {
+  static void set(alias_ref<JArrayClass<jobject>> array) {
     (void)array;
   }
 };
 
 template <typename... Args>
-local_ref<JArrayClass<jobject>::javaobject> makeArgsArray(Args... args) {
+local_ref<JArrayClass<jobject>> makeArgsArray(Args... args) {
   auto arr = JArrayClass<jobject>::newArray(sizeof...(args));
   ArgsArraySetter<0, Args...>::set(arr, args...);
   return arr;

--- a/test/jni/iterator_tests.cpp
+++ b/test/jni/iterator_tests.cpp
@@ -22,7 +22,7 @@ struct JHashMap : public JavaClass<JHashMap<K,V>, JMap<K,V>> {
 
 jboolean nativeTestListIterator(
     alias_ref<jclass>,
-    alias_ref<JList<jstring>::javaobject> jlist) {
+    alias_ref<JList<jstring>> jlist) {
   EXPECT(jlist);
 
   EXPECT(jlist->size() == 3);
@@ -62,7 +62,7 @@ jboolean nativeTestListIterator(
 
 jboolean nativeTestMapIterator(
     alias_ref<jclass>,
-    alias_ref<JMap<jstring, JInteger::javaobject>::javaobject> jmap) {
+    alias_ref<JMap<jstring, JInteger::javaobject>> jmap) {
   EXPECT(jmap);
 
   EXPECT(jmap->size() == 3);
@@ -98,7 +98,7 @@ jboolean nativeTestMapIterator(
 
 jboolean nativeTestIterateWrongType(
     alias_ref<jclass>,
-    alias_ref<JMap<jstring, JInteger::javaobject>::javaobject> jmap) {
+    alias_ref<JMap<jstring, JInteger::javaobject>> jmap) {
   EXPECT(jmap);
 
   EXPECT(jmap->size() == 3);
@@ -115,7 +115,7 @@ jboolean nativeTestIterateWrongType(
 
 jboolean nativeTestIterateNullKey(
     alias_ref<jclass>,
-    alias_ref<JMap<jstring, JInteger::javaobject>::javaobject> jmap) {
+    alias_ref<JMap<jstring, JInteger::javaobject>> jmap) {
   EXPECT(jmap);
 
   EXPECT(jmap->size() == 3);
@@ -144,7 +144,7 @@ jboolean nativeTestIterateNullKey(
 
 jboolean nativeTestLargeMapIteration(
     alias_ref<jclass>,
-    alias_ref<JMap<jstring, jstring>::javaobject> jmap) {
+    alias_ref<JMap<jstring, jstring>> jmap) {
   EXPECT(jmap);
   EXPECT(jmap->size() == 3000);
 


### PR DESCRIPTION
Summary:
These all handle JavaClass types.

Test Plan:
CI