### PR TITLE
Use a more specific return type for autoboxing

### DIFF
--- a/cxx/fbjni/detail/Boxed.h
+++ b/cxx/fbjni/detail/Boxed.h
@@ -50,7 +50,7 @@ struct JPrimitive : JavaClass<T> {
       return value();                                                \
     }                                                                \
   };                                                                 \
-  inline local_ref<jobject> autobox(j ## LITTLE val) {               \
+  inline local_ref<J ## BIG::javaobject> autobox(j ## LITTLE val) {  \
     return J ## BIG::valueOf(val);                                   \
   }
 


### PR DESCRIPTION
Summary:
Allows capturing by local_ref explicitly without casting.

Test Plan:
CI