### PR TITLE
Fix argument name in make_jstring

### DIFF
--- a/cxx/fbjni/detail/CoreClasses-inl.h
+++ b/cxx/fbjni/detail/CoreClasses-inl.h
@@ -330,8 +330,8 @@ inline void registerNatives(const char* name, std::initializer_list<NativeMethod
 
 // jstring /////////////////////////////////////////////////////////////////////////////////////////
 
-inline local_ref<JString> make_jstring(const std::string& modifiedUtf8) {
-  return make_jstring(modifiedUtf8.c_str());
+inline local_ref<JString> make_jstring(const std::string& utf8) {
+  return make_jstring(utf8.c_str());
 }
 
 namespace detail {

--- a/cxx/fbjni/detail/CoreClasses.h
+++ b/cxx/fbjni/detail/CoreClasses.h
@@ -363,8 +363,8 @@ class JString : public JavaClass<JString, JObject, jstring> {
 
 /// Convenience functions to convert a const char*, std::string, or std::u16string
 /// into a @ref local_ref to a jstring.
-local_ref<JString> make_jstring(const char* modifiedUtf8);
-local_ref<JString> make_jstring(const std::string& modifiedUtf8);
+local_ref<JString> make_jstring(const char* utf8);
+local_ref<JString> make_jstring(const std::string& utf8);
 local_ref<JString> make_jstring(const std::u16string& utf16);
 
 namespace detail {


### PR DESCRIPTION
Summary:
These take real UTF-8, not modified.

Test Plan:
CI