### PR TITLE
Support get[Static]Field without ::javaobject

### DIFF
--- a/cxx/fbjni/detail/CoreClasses-inl.h
+++ b/cxx/fbjni/detail/CoreClasses-inl.h
@@ -256,35 +256,35 @@ inline JNonvirtualMethod<F> JClass::getNonvirtualMethod(
 }
 
 template<typename T>
-inline JField<enable_if_t<IsJniScalar<T>(), T>>
+inline JField<PrimitiveOrJniType<T>>
 JClass::getField(const char* name) const {
   return getField<T>(name, jtype_traits<T>::descriptor().c_str());
 }
 
 template<typename T>
-inline JField<enable_if_t<IsJniScalar<T>(), T>> JClass::getField(
+inline JField<PrimitiveOrJniType<T>> JClass::getField(
     const char* name,
     const char* descriptor) const {
   const auto env = Environment::current();
   auto field = env->GetFieldID(self(), name, descriptor);
   FACEBOOK_JNI_THROW_EXCEPTION_IF(!field);
-  return JField<T>{field};
+  return JField<PrimitiveOrJniType<T>>{field};
 }
 
 template<typename T>
-inline JStaticField<enable_if_t<IsJniScalar<T>(), T>> JClass::getStaticField(
+inline JStaticField<PrimitiveOrJniType<T>> JClass::getStaticField(
     const char* name) const {
   return getStaticField<T>(name, jtype_traits<T>::descriptor().c_str());
 }
 
 template<typename T>
-inline JStaticField<enable_if_t<IsJniScalar<T>(), T>> JClass::getStaticField(
+inline JStaticField<PrimitiveOrJniType<T>> JClass::getStaticField(
     const char* name,
     const char* descriptor) const {
   const auto env = Environment::current();
   auto field = env->GetStaticFieldID(self(), name, descriptor);
   FACEBOOK_JNI_THROW_EXCEPTION_IF(!field);
-  return JStaticField<T>{field};
+  return JStaticField<PrimitiveOrJniType<T>>{field};
 }
 
 template<typename T>

--- a/cxx/fbjni/detail/CoreClasses.h
+++ b/cxx/fbjni/detail/CoreClasses.h
@@ -288,19 +288,19 @@ class JClass : public JavaClass<JClass, JObject, jclass> {
 
   /// Lookup the field with the given name and deduced descriptor
   template<typename T>
-  JField<enable_if_t<IsJniScalar<T>(), T>> getField(const char* name) const;
+  JField<PrimitiveOrJniType<T>> getField(const char* name) const;
 
   /// Lookup the field with the given name and descriptor
   template<typename T>
-  JField<enable_if_t<IsJniScalar<T>(), T>> getField(const char* name, const char* descriptor) const;
+  JField<PrimitiveOrJniType<T>> getField(const char* name, const char* descriptor) const;
 
   /// Lookup the static field with the given name and deduced descriptor
   template<typename T>
-  JStaticField<enable_if_t<IsJniScalar<T>(), T>> getStaticField(const char* name) const;
+  JStaticField<PrimitiveOrJniType<T>> getStaticField(const char* name) const;
 
   /// Lookup the static field with the given name and descriptor
   template<typename T>
-  JStaticField<enable_if_t<IsJniScalar<T>(), T>> getStaticField(
+  JStaticField<PrimitiveOrJniType<T>> getStaticField(
       const char* name,
       const char* descriptor) const;
 

--- a/cxx/fbjni/detail/References-forward.h
+++ b/cxx/fbjni/detail/References-forward.h
@@ -40,6 +40,9 @@ struct JavaObjectType;
 
 template <typename T>
 struct ReprAccess;
+
+template <typename T, typename Enable = void>
+struct PrimitiveOrJavaObjectType;
 }
 
 // Given T, either a jobject-like type or a JavaClass-derived type, ReprType<T>
@@ -50,6 +53,9 @@ using ReprType = typename detail::RefReprType<T>::type;
 
 template <typename T>
 using JniType = typename detail::JavaObjectType<T>::type;
+
+template <typename T>
+using PrimitiveOrJniType = typename detail::PrimitiveOrJavaObjectType<T>::type;
 
 template<typename T, typename Alloc>
 class base_owned_ref;

--- a/cxx/fbjni/detail/References.h
+++ b/cxx/fbjni/detail/References.h
@@ -188,6 +188,33 @@ struct JavaObjectType<T*> {
       "JavaObjectType<T> not idempotent");
 };
 
+template <typename T>
+struct PrimitiveOrJavaObjectType<T, enable_if_t<IsJniPrimitive<T>(), void>> {
+  using type = T;
+  static_assert(IsJniPrimitive<type>(),
+      "PrimitiveOrJavaObjectType<T> not a jni primitive");
+  static_assert(std::is_same<type, typename PrimitiveOrJavaObjectType<type>::type>::value,
+      "PrimitiveOrJavaObjectType<T> not idempotent");
+};
+
+template <typename T>
+struct PrimitiveOrJavaObjectType<T, enable_if_t<IsPlainJniReference<T>(), void>> {
+  using type = T;
+  static_assert(IsPlainJniReference<type>(),
+      "PrimitiveOrJavaObjectType<T> not a plain jni reference");
+  static_assert(std::is_same<type, typename PrimitiveOrJavaObjectType<type>::type>::value,
+      "PrimitiveOrJavaObjectType<T> not idempotent");
+};
+
+template <typename T>
+struct PrimitiveOrJavaObjectType<T, enable_if_t<IsJavaClassType<T>(), void>> {
+  using type = JniType<T>;
+  static_assert(IsPlainJniReference<type>(),
+      "PrimitiveOrJavaObjectType<T> not a plain jni reference");
+  static_assert(std::is_same<type, typename PrimitiveOrJavaObjectType<type>::type>::value,
+      "PrimitiveOrJavaObjectType<T> not idempotent");
+};
+
 template <typename Repr>
 struct ReprStorage {
   explicit ReprStorage(JniType<Repr> obj) noexcept;

--- a/test/jni/doc_tests.cpp
+++ b/test/jni/doc_tests.cpp
@@ -76,14 +76,14 @@ struct JDataHolder : JavaClass<JDataHolder> {
     jint i = this->getFieldValue(iField);
     this->setFieldValue(iField, i + 1);
     // Object fields work for standard classes and your own JavaObject classes.
-    static const auto sField = cls->getField<JString::javaobject>("s");
+    static const auto sField = cls->getField<JString>("s");
     // Object are returned as local refs ...
     local_ref<JString> s = this->getFieldValue(sField);
     // and can be set from any ref.
     this->setFieldValue(sField, make_jstring(s->toStdString() + "1").get());
     // Static fields work the same, but getStaticField, getStaticFieldValue,
     // and setStaticFieldValue must all be called on the class object.
-    static const auto someInstanceField = cls->getStaticField<JDataHolder::javaobject>("someInstance");
+    static const auto someInstanceField = cls->getStaticField<JDataHolder>("someInstance");
     auto inst = cls->getStaticFieldValue(someInstanceField);
     if (!inst) {
       // NOTE: Can't use cls here because it is declared const.

--- a/test/jni/fbjni_tests.cpp
+++ b/test/jni/fbjni_tests.cpp
@@ -1433,6 +1433,12 @@ void RegisterFbjniTests() {
   StaticAssertSame<JniType<jFakeClass>, jFakeClass>();
   StaticAssertSame<JniType<JObjectWrapper<jFakeClass>>, jFakeClass>();
 
+  StaticAssertSame<PrimitiveOrJniType<JObject>, jobject>();
+  StaticAssertSame<PrimitiveOrJniType<JClass>, jclass>();
+  StaticAssertSame<PrimitiveOrJniType<JArrayInt>, jintArray>();
+  StaticAssertSame<PrimitiveOrJniType<jint>, jint>();
+  StaticAssertSame<PrimitiveOrJniType<TestThing>, TestThing::javaobject>();
+
   registerNatives(jaccess_class_name, {
       makeNativeMethod("nativeTestClassResolution", TestClassResolution),
       makeNativeMethod("nativeTestLazyClassResolution", TestLazyClassResolution),


### PR DESCRIPTION
Treat getField<JFoo> as equivalent to getField<JniType<JFoo>>,
which is equivalent to getField<JFoo::javaobject>.

This required introducing a new metaprogramming struct,
`PrimitiveOrJniType`, which works like `JniType`, but passes through
Java primitives.

Test Plan:
CI
