### PR TITLE
Support getMethod without ::javaobject or local_ref in return

### DIFF
--- a/cxx/fbjni/ByteBuffer.cpp
+++ b/cxx/fbjni/ByteBuffer.cpp
@@ -85,7 +85,7 @@ local_ref<JByteBuffer> JByteBuffer::wrapBytes(uint8_t* data, size_t size) {
 
 local_ref<JByteBuffer> JByteBuffer::allocateDirect(jint size) {
   static auto cls = JByteBuffer::javaClassStatic();
-  static auto meth = cls->getStaticMethod<JByteBuffer::javaobject(int)>("allocateDirect");
+  static auto meth = cls->getStaticMethod<JByteBuffer(int)>("allocateDirect");
   return meth(cls, size);
 }
 

--- a/cxx/fbjni/Context.h
+++ b/cxx/fbjni/Context.h
@@ -28,12 +28,12 @@ class AContext : public JavaClass<AContext> {
 
   // Define a method that calls into the represented Java class
   local_ref<JFile> getCacheDir() {
-    static const auto method = getClass()->getMethod<JFile::javaobject()>("getCacheDir");
+    static const auto method = getClass()->getMethod<JFile()>("getCacheDir");
     return method(self());
   }
 
   local_ref<JFile> getFilesDir() {
-    static const auto method = getClass()->getMethod<JFile::javaobject()>("getFilesDir");
+    static const auto method = getClass()->getMethod<JFile()>("getFilesDir");
     return method(self());
   }
 };

--- a/cxx/fbjni/detail/Meta-inl.h
+++ b/cxx/fbjni/detail/Meta-inl.h
@@ -111,7 +111,9 @@ class JMethod<R(Args...)> : public JMethodBase {
  public:
    // TODO: static_assert is jobject-derived or local_ref jobject
   using JniRet = typename detail::Convert<typename std::decay<R>::type>::jniType;
-  static_assert(IsPlainJniReference<JniRet>(), "JniRet must be a JNI reference");
+  static_assert(
+      IsPlainJniReference<JniRet>() || detail::IsJavaClassType<JniRet>(),
+      "Return type must be a JNI reference or JavaClass type.");
   using JMethodBase::JMethodBase;
   JMethod() noexcept {};
   JMethod(const JMethod& other) noexcept = default;
@@ -130,7 +132,7 @@ inline auto JMethod<R(Args...)>::operator()(alias_ref<jobject> self, Args... arg
       getId(),
       detail::callToJni(detail::Convert<typename std::decay<Args>::type>::toCall(args))...);
   FACEBOOK_JNI_THROW_PENDING_EXCEPTION();
-  return adopt_local(static_cast<JniRet>(result));
+  return adopt_local(static_cast<JniType<JniRet>>(result));
 }
 
 template<typename... Args>
@@ -173,7 +175,9 @@ class JStaticMethod<R(Args...)> : public JMethodBase {
 
  public:
   using JniRet = typename detail::Convert<typename std::decay<R>::type>::jniType;
-  static_assert(IsPlainJniReference<JniRet>(), "T* must be a JNI reference");
+  static_assert(
+      IsPlainJniReference<JniRet>() || detail::IsJavaClassType<JniRet>(),
+      "Return type must be a JNI reference or JavaClass type.");
   using JMethodBase::JMethodBase;
   JStaticMethod() noexcept {};
   JStaticMethod(const JStaticMethod& other) noexcept = default;
@@ -186,7 +190,7 @@ class JStaticMethod<R(Args...)> : public JMethodBase {
           getId(),
           detail::callToJni(detail::Convert<typename std::decay<Args>::type>::toCall(args))...);
     FACEBOOK_JNI_THROW_PENDING_EXCEPTION();
-    return adopt_local(static_cast<JniRet>(result));
+    return adopt_local(static_cast<JniType<JniRet>>(result));
   }
 
   friend class JClass;
@@ -235,7 +239,9 @@ template<typename R, typename... Args>
 class JNonvirtualMethod<R(Args...)> : public JMethodBase {
  public:
   using JniRet = typename detail::Convert<typename std::decay<R>::type>::jniType;
-  static_assert(IsPlainJniReference<JniRet>(), "T* must be a JNI reference");
+  static_assert(
+      IsPlainJniReference<JniRet>() || detail::IsJavaClassType<JniRet>(),
+      "Return type must be a JNI reference or JavaClass type.");
   using JMethodBase::JMethodBase;
   JNonvirtualMethod() noexcept {};
   JNonvirtualMethod(const JNonvirtualMethod& other) noexcept = default;
@@ -249,7 +255,7 @@ class JNonvirtualMethod<R(Args...)> : public JMethodBase {
           getId(),
           detail::callToJni(detail::Convert<typename std::decay<Args>::type>::toCall(args))...);
     FACEBOOK_JNI_THROW_PENDING_EXCEPTION();
-    return adopt_local(static_cast<JniRet>(result));
+    return adopt_local(static_cast<JniType<JniRet>>(result));
   }
 
   friend class JClass;

--- a/test/jni/doc_tests.cpp
+++ b/test/jni/doc_tests.cpp
@@ -176,7 +176,7 @@ struct DocTests : JavaClass<DocTests> {
     // Convert JString to std::string.
     std::string result = s1->toStdString();
     // Java methods can receive and return JString ...
-    static const auto doubler_java = clazz->getStaticMethod<local_ref<JString>(JString)>("doubler");
+    static const auto doubler_java = clazz->getStaticMethod<JString(JString)>("doubler");
     result += doubler_java(clazz, *s1)->toStdString();
     // and also std::string (converted from real UTF-8).
     static const auto doubler_std = clazz->getStaticMethod<std::string(std::string)>("doubler");

--- a/test/jni/iterator_tests.cpp
+++ b/test/jni/iterator_tests.cpp
@@ -62,7 +62,7 @@ jboolean nativeTestListIterator(
   EXPECT(vs1 == vs3);
 
   static auto iteratorMethod =
-    JIterable<jstring>::javaClassStatic()->getMethod<JIterator<jstring>::javaobject()>("iterator");
+    JIterable<jstring>::javaClassStatic()->getMethod<JIterator<jstring>()>("iterator");
   auto iter = iteratorMethod(jlist);
 
   EXPECT(std::equal(iter->begin(), iter->end(), jlist->begin()));


### PR DESCRIPTION
Summary:
Treat getMethod<JFoo> as equivalent to getMethod<JniType<JFoo>>,
which is equivalent to getMethod<JFoo::javaobject>.

Update all call sites.  Some were calling getMethod<local_ref<JFoo>>,
which is equivalent.

Test Plan:
CI
