### PR TITLE
Support JArrayClass without ::javaobject and document its use

### DIFF
--- a/cxx/fbjni/detail/CoreClasses-inl.h
+++ b/cxx/fbjni/detail/CoreClasses-inl.h
@@ -436,16 +436,16 @@ auto JArrayClass<T>::newArray(size_t size) -> local_ref<javaobject> {
 }
 
 template<typename T>
-inline void JArrayClass<T>::setElement(size_t idx, const T& value) {
+inline void JArrayClass<T>::setElement(size_t idx, T value) {
   const auto env = Environment::current();
-  env->SetObjectArrayElement(this->self(), idx, value);
+  env->SetObjectArrayElement(this->self(), idx, detail::toPlainJniReference(value));
 }
 
 template<typename T>
 inline local_ref<T> JArrayClass<T>::getElement(size_t idx) {
   const auto env = Environment::current();
   auto rawElement = env->GetObjectArrayElement(this->self(), idx);
-  return adopt_local(static_cast<T>(rawElement));
+  return adopt_local(static_cast<JniType<T>>(rawElement));
 }
 
 template<typename T>

--- a/cxx/fbjni/detail/CoreClasses.h
+++ b/cxx/fbjni/detail/CoreClasses.h
@@ -415,8 +415,10 @@ class JTypeArray : public JavaClass<JTypeArray, JArray, jobjectArray> {
 template<typename T>
 class JArrayClass : public JavaClass<JArrayClass<T>, detail::JTypeArray> {
  public:
-  static_assert(is_plain_jni_reference<T>(), "");
-  // javaentry is the jni type of an entry in the array (i.e. jint).
+  static_assert(
+      IsPlainJniReference<JniType<T>>(),
+      "Element type must be a JNI reference or JavaClass type.");
+  // javaentry is the jni type of an entry in the array (i.e. JObject).
   using javaentry = T;
   // javaobject is the jni type of the array.
   using javaobject = typename JavaClass<JArrayClass<T>, detail::JTypeArray>::javaobject;
@@ -431,7 +433,7 @@ class JArrayClass : public JavaClass<JArrayClass<T>, detail::JTypeArray> {
 
   /// Assign an object to the array.
   /// Typically you will use the shorthand (*ref)[idx]=value;
-  void setElement(size_t idx, const T& value);
+  void setElement(size_t idx, T value);
 
   /// Read an object from the array.
   /// Typically you will use the shorthand

--- a/cxx/fbjni/detail/MetaConvert.h
+++ b/cxx/fbjni/detail/MetaConvert.h
@@ -40,6 +40,16 @@ inline JniType<T> callToJni(local_ref<T>&& sref) {
   return sref.get();
 }
 
+template<typename T>
+enable_if_t<IsPlainJniReference<T>(), T> toPlainJniReference(T obj) {
+  return obj;
+}
+
+template<typename T>
+enable_if_t<IsJavaClassType<T>(), JniType<T>> toPlainJniReference(T repr) {
+  return ReprAccess<T>::get(repr);
+}
+
 // Normally, pass through types unmolested.
 template <typename T, typename Enabled = void>
 struct Convert {

--- a/docs/quickref_toc.txt
+++ b/docs/quickref_toc.txt
@@ -4,6 +4,7 @@ basic_methods Basic method usage (Java to C++ and C++ to Java)
 primitives Methods using Java primitives
 strings Methods using Java Strings
 primitive_arrays Working with arrays of primitives
+class_arrays Working with arrays of objects
 references References
 nested_class Defining a nested class
 inheritance Defining a child class

--- a/test/jni/doc_tests.cpp
+++ b/test/jni/doc_tests.cpp
@@ -91,6 +91,12 @@ struct JDataHolder : JavaClass<JDataHolder> {
     }
   }
   // END
+
+  local_ref<JString> getStr() {
+    static const auto cls = javaClassStatic();
+    static const auto sField = cls->getField<JString>("s");
+    return getFieldValue(sField);
+  }
 };
 
 
@@ -218,6 +224,20 @@ struct DocTests : JavaClass<DocTests> {
     // (Data can also be assigned by writing to a pin.)
     auto ret = JArrayInt::newArray(size + 1);
     ret->setRegion(0, size + 1, buffer.data());
+    return ret;
+  }
+  // END
+
+  // SECTION class_arrays
+  static local_ref<JArrayClass<JString>> classArrays(
+      alias_ref<JClass> clazz,
+      alias_ref<JArrayClass<JDataHolder>> arr) {
+    size_t size = arr->size();
+    local_ref<JArrayClass<JString>> ret = JArrayClass<JString>::newArray(size);
+    for (int i = 0; i < size; ++i) {
+      local_ref<JString> str = arr->getElement(i)->getStr();
+      ret->setElement(i, *str);
+    }
     return ret;
   }
   // END


### PR DESCRIPTION
Summary:
- Change the static_assert to allow JavaClass types.
- Change pointer cast in getElement to use JniType.
- In setElement, use new toPlainJniReference that converts JavaClass
  values to plain JNI references using ReprAccess.
- NOTE: Maybe we should do this last one in JMethod::operator() as well,
  since it currently passes JavaClass values directly to env->Invoke*

Test Plan:
CI
