### PR TITLE
Add ApplicationManifest

### DIFF
--- a/ApplicationManifest.xml
+++ b/ApplicationManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.facebook.fbjni">
+</manifest>


### PR DESCRIPTION
Summary:
This is used by the generateReleaseBuildConfig, which is needed when
fbjni is included as a submodule.

Test Plan:
`./gradlew generateReleaseBuildConfig`
(In PyTorch) `./gradlew assembleRelease`