### PR TITLE
Reduce minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.6.0)
+cmake_minimum_required(VERSION 3.5.0)
 project(fbjni CXX)
 
 set(FBJNI_COMPILE_OPTIONS


### PR DESCRIPTION
PyTorch's open-source CI environment has CMake 3.5.1.  Looking at the
release notes, there's nothing obvious in 3.6 that we need, especially
with fbjni tests disabled.