### PR TITLE
Fix build with gcc

### DIFF
--- a/cxx/fbjni/detail/Meta.h
+++ b/cxx/fbjni/detail/Meta.h
@@ -294,11 +294,11 @@ private:
  public:
   // The jni type signature (described at
   // http://docs.oracle.com/javase/1.5.0/docs/guide/jni/spec/types.html).
-  static constexpr decltype(descriptor()) /* detail::SimpleFixedString<_> */ kDescriptor = descriptor();
+  static constexpr decltype(jtype_traits<T>::descriptor()) /* detail::SimpleFixedString<_> */ kDescriptor = descriptor();
 
   // The signature used for class lookups. See
   // http://docs.oracle.com/javase/6/docs/api/java/lang/Class.html#getName().
-  static constexpr decltype(base_name()) /* detail::SimpleFixedString<_> */ kBaseName = base_name();
+  static constexpr decltype(jtype_traits<T>::base_name()) /* detail::SimpleFixedString<_> */ kBaseName = base_name();
 };
 
 template <typename T>

--- a/cxx/fbjni/detail/SimpleFixedString.h
+++ b/cxx/fbjni/detail/SimpleFixedString.h
@@ -19,9 +19,16 @@
 #pragma once
 
 #include <cassert>
+#include <cstring>
 #include <stdexcept>
 #include <string>
 #include <utility>
+
+#if defined(__has_feature)
+#define FBJNI_HAS_FEATURE(...) __has_feature(__VA_ARGS__)
+#else
+#define FBJNI_HAS_FEATURE(...) 0
+#endif
 
 namespace facebook {
 namespace jni {
@@ -50,7 +57,7 @@ static_assert(
     "Someone appears to have broken constexpr_strlen...");
 
 constexpr size_t constexpr_strlen(const char* s) {
-#if defined(__has_feature) && __has_feature(cxx_constexpr_string_builtins)
+#if FBJNI_HAS_FEATURE(cxx_constexpr_string_builtins)
   // clang provides a constexpr builtin
   return __builtin_strlen(s);
 #elif defined(__GNUC__) && !defined(__clang__)


### PR DESCRIPTION
kDescriptor needs full qualification because gcc complained of a
mismatched declaration and definition otherwise.

SimpleFixedString conditions were reordered because
`#if defined(foo) && foo(bar)` is a preprocessor syntax error with gcc.