### PR TITLE
Switch CI to use Clang

### DIFF
--- a/scripts/run-host-tests.sh
+++ b/scripts/run-host-tests.sh
@@ -17,6 +17,7 @@ set -exo pipefail
 
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
 CMAKE=$ANDROID_HOME/cmake/3.10.2.4988404/bin/cmake
+export CXX=clang++
 
 mkdir -p "$BASE_DIR/host-build-cmake"
 cd "$BASE_DIR/host-build-cmake"


### PR DESCRIPTION
GCC 7.4 (which is what GitHub Actions supports) is having trouble
compiling the latest trunk, even though we think it is valid C++14.