### PR TITLE
fix const issue when assigning to non-const char*

### DIFF
--- a/cxx/fbjni/detail/Environment.cpp
+++ b/cxx/fbjni/detail/Environment.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <vector>
 #include <fbjni/fbjni.h>
 
 #ifdef __ANDROID__
@@ -93,7 +94,8 @@ JNIEnv* attachCurrentThread() {
 
   const auto threadName = getThreadName();
   if (threadName.size()) {
-    args.name = threadName.c_str();
+    std::vector<char> v(threadName.begin(), threadName.end());
+    args.name = &v[0];
   }
 
   using AttachEnvType =

--- a/cxx/fbjni/detail/Environment.cpp
+++ b/cxx/fbjni/detail/Environment.cpp
@@ -93,8 +93,9 @@ JNIEnv* attachCurrentThread() {
   JavaVMAttachArgs args{JNI_VERSION_1_6, nullptr, nullptr};
 
   const auto threadName = getThreadName();
+  std::vector<char> v;
   if (threadName.size()) {
-    std::vector<char> v(threadName.begin(), threadName.end());
+    v.assign(threadName.begin(), threadName.end());
     args.name = &v[0];
   }
 


### PR DESCRIPTION
## Motivation

To fix the build.

## Summary

A raw assignment to a C-string copy.

How does the code work?

It copies by the `threadName` into a `std::vector<char>` which can then be referenced as a `char*`.

Why did you choose this approach?

Because `strcpy` is scary and it wasn't working anyway.

## Test Plan

CI. 

