### PR TITLE
add install target, which is expected by PyTorch.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,5 +111,6 @@ install(EXPORT fbjniLibraryConfig DESTINATION share/cmake/fbjni
   FILE fbjniLibraryConfig.cmake)
 
 if(MSVC)
-  install(TARGETS fbjni DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(FILES $<TARGET_PDB_FILE:fbjni> DESTINATION ${CMAKE_INSTALL_LIBDIR} OPTIONAL)  
+    install(TARGETS fbjni DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,8 @@ set_target_properties(fbjni PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 target_compile_options(fbjni PRIVATE ${FBJNI_COMPILE_OPTIONS})
 target_compile_options(fbjni PRIVATE -DBUILDING_FBJNI)
 
-target_include_directories(fbjni PUBLIC
-  cxx
+target_include_directories(fbjni BEFORE
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cxx> 
 )
 
 if (NOT ANDROID_ABI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@
 cmake_minimum_required(VERSION 3.5.0)
 project(fbjni CXX)
 
+include(GNUInstallDirs)
+
 set(FBJNI_COMPILE_OPTIONS
   -Wall
   -std=c++14
@@ -100,3 +102,14 @@ if (ANDROID_ABI)
   )
 endif()
 
+install(TARGETS fbjni EXPORT fbjniLibraryConfig
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}) #For windows
+
+install(EXPORT fbjniLibraryConfig DESTINATION share/cmake/fbjni
+  FILE fbjniLibraryConfig.cmake)
+
+if(MSVC)
+  install(TARGETS fbjni DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()


### PR DESCRIPTION
## Motivation

Apparently pytorch_jni expects dependent libraries to have an install target. 

## Summary

Added install target with some Windows-specific install dirs. Based on [FBGEMM](https://github.com/pytorch/FBGEMM/blob/master/CMakeLists.txt#L240), which works in build.
