### PR TITLE
Enable prefab

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.6.0)
 project(fbjni CXX)
 
 include(GNUInstallDirs)

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ repositories {
 android {
     compileSdkVersion 29
     buildToolsVersion '29.0.3'
+    ndkVersion '21.1.6352462'
 
     externalNativeBuild {
         cmake {
@@ -66,8 +67,9 @@ android {
 
         externalNativeBuild {
             cmake {
-                arguments '-DANDROID_TOOLCHAIN=clang'
+                arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_shared'
                 targets 'fbjni'
+                version '3.10.2.4988404'
             }
         }
 
@@ -79,6 +81,14 @@ android {
             fbjni {
                 headers 'cxx/'
             }
+        }
+
+        // There's a bug in prefab that will bundle all these twice, causing the
+        // consumer to get duplicate errors.
+        // Followed the advice from https://github.com/chancezeus/libjpeg-turbo-android-prefab/blob/18eaa325e9954b832c9f3c95e141361d86746528/libjpeg-turbo/build.gradle
+        packagingOptions {
+            exclude("**/libfbjni.so")
+            exclude("**/libc++_shared.so")
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,19 @@ android {
                 targets 'fbjni'
             }
         }
+
+        buildFeatures {
+            prefabPublishing true
+        }
+
+        prefab {
+            fbjni {
+                headers 'cxx/'
+            }
+        }
     }
 }
+
 
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'

--- a/gradle/android-tasks.gradle
+++ b/gradle/android-tasks.gradle
@@ -99,7 +99,7 @@ afterEvaluate { project ->
 }
 
 // Utility method to extract only one entry in a zip file
-private def extractEntry(archive, entryPath, outputPath) {
+private static def extractEntry(archive, entryPath, outputPath) {
     if (!archive.exists()) {
         throw new GradleException("archive $archive not found")
     }


### PR DESCRIPTION
Summary:

This enables the long-awaited "prefab" mode which is a proper binary and header distribution for pre-built binaries. More on that here: https://google.github.io/prefab/.

This will likely break backwards-compatibility with packages not using prefab, so we will want to at least bump the minor version for the next release.

Test Plan:

./gradlew assemble

`unzip -l build/outputs/aar/fbjni-release.aar` shows we've got headers (well, actually all source) plus binaries in a `prefab/` folder.

Checked that this builds with Flipper by publishing it locally.
