### PR TITLE
[docs] Add updated integration instructions

### DIFF
--- a/docs/android_setup.md
+++ b/docs/android_setup.md
@@ -1,5 +1,36 @@
 ## Android Build Setup
 
+**These instructions require the Android Gradle Build Plugin 4.0.0 or newer
+as it relies on the new [prefab](https://android-developers.googleblog.com/2020/02/native-dependencies-in-android-studio-40.html) integration.
+Check below for a pre-4.0.0 workaround.**
+
+```
+repositories {
+  maven {
+    mavenCentral()
+  }
+}
+
+android {
+  dependencies {
+    implementation 'com.facebook.fbjni:fbjni:0.1.0'
+  }
+}
+```
+
+Now, in your CMake setup, you can refer to the `fbjni` package. The header files (e.g. `fbjni.h`)
+will available implicitly.
+
+```cmake
+set(build_DIR ${CMAKE_SOURCE_DIR}/build)
+
+find_package(fbjni REQUIRED CONFIG)
+
+target_link_libraries(${PACKAGE_NAME} fbjni::fbjni mylibrary)
+```
+
+## Android Build Setup (pre-4.0.0)
+
 The Android Gradle plugin does not provide built-in support for artifacts that
 include native libraries (for linking against) and header files. Because of
 that, some manual additions to your build system are required. The following

--- a/docs/android_setup.md
+++ b/docs/android_setup.md
@@ -4,7 +4,7 @@
 as it relies on the new [prefab](https://android-developers.googleblog.com/2020/02/native-dependencies-in-android-studio-40.html) integration.
 Check below for a pre-4.0.0 workaround.**
 
-```
+```groovy
 repositories {
   maven {
     mavenCentral()
@@ -23,6 +23,7 @@ will available implicitly.
 
 ```cmake
 set(build_DIR ${CMAKE_SOURCE_DIR}/build)
+set(PACKAGE_NAME "myapp")
 
 find_package(fbjni REQUIRED CONFIG)
 
@@ -104,6 +105,7 @@ Now, in your CMake setup, you can refer to the extracted paths:
 
 ```cmake
 set(build_DIR ${CMAKE_SOURCE_DIR}/build)
+set(PACKAGE_NAME "myapp")
 
 file(GLOB libfbjni_link_DIRS "${build_DIR}/fbjni*.aar/jni/${ANDROID_ABI}")
 file(GLOB libfbjni_include_DIRS "${build_DIR}/fbjni-*-headers.jar/")


### PR DESCRIPTION
Summary:
Added a *much shorter* set of instructions to integrate with
the build plugin 4.0.

Test Plan:
_eyes
