### PR TITLE
Remove the package exclusions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,14 +81,6 @@ android {
                 headers 'cxx/'
             }
         }
-
-        // There's a bug in prefab that will bundle all these twice, causing the
-        // consumer to get duplicate errors.
-        // Followed the advice from https://github.com/chancezeus/libjpeg-turbo-android-prefab/blob/18eaa325e9954b832c9f3c95e141361d86746528/libjpeg-turbo/build.gradle
-        packagingOptions {
-            exclude("**/libfbjni.so")
-            exclude("**/libc++_shared.so")
-        }
     }
 }
 


### PR DESCRIPTION
Summary:
It's all a little confusing but downstream consumers of Flipper
that don't use CMake themselves otherwise don't have access to these
libraries and will have them missing from their builds.

I'll create an 0.2.0 release for this so 0.1.0 consumers don't
end up with multiple binaries.

Test Plan:
Tested locally with Flipper and a stand-alone example and it seems to
work.
