### PR TITLE
Publish headers archive again

### DIFF
--- a/gradle/android-tasks.gradle
+++ b/gradle/android-tasks.gradle
@@ -15,13 +15,15 @@
  */
 
 afterEvaluate { project ->
-    if (POM_PACKAGING == 'aar') {
-        task headersJar(type: Jar) {
-            archiveClassifier.set('headers')
-            from("$rootDir/cxx/") {
-                include '**/*.h'
-            }
+    task headersJar(type: Jar) {
+        archiveClassifier.set('headers')
+        from("$rootDir/cxx/") {
+            include '**/*.h'
         }
-        artifacts.add('archives', headersJar)
+    }
+
+    def gradlePublishing = extensions.getByType(PublishingExtension.class)
+    gradlePublishing.publications.create("headers", MavenPublication.class) {
+      artifact(headersJar)
     }
 }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
+apply plugin: 'com.vanniktech.maven.publish'
+
 // Common Android tasks for all releases that generate Javadocs, sources, etc.
 apply from: rootProject.file('gradle/android-tasks.gradle')
-
-apply plugin: 'com.vanniktech.maven.publish'


### PR DESCRIPTION
Summary:
This broke with the switch to the new gradle release plugin.
Read the source of it and while I'm not sure if it's the right way to do
it, it seems to work.

Test Plan:
```
$ ./gradlew installArchives
$ ls ~/.m2/repository/com/facebook/fbjni/fbjni/0.2.1-SNAPSHOT/
```

Contains a headers archive again.

```
unzip -l ~/.m2/repository/com/facebook/fbjni/fbjni/0.2.1-SNAPSHOT/fbjni-0.2.1-20210322.182921-1-headers.jar
Archive:  /Users/realpassy/.m2/repository/com/facebook/fbjni/fbjni/0.2.1-SNAPSHOT/fbjni-0.2.1-20210322.182921-1-headers.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  03-22-2021 18:29   META-INF/
       25  02-19-2021 12:28   META-INF/MANIFEST.MF
        0  01-23-2020 14:25   fbjni/
     2056  01-23-2020 14:25   fbjni/JThread.h
      951  01-23-2020 14:25   fbjni/ReadableByteChannel.h
     1336  01-23-2020 14:25   fbjni/NativeRunnable.h
     1050  01-23-2020 14:25   fbjni/File.h
     1088  01-23-2020 14:25   fbjni/fbjni.h
     1215  01-23-2020 14:25   fbjni/Context.h
     1759  01-23-2020 14:25   fbjni/ByteBuffer.h
        0  02-18-2021 11:31   fbjni/detail/
    11992  01-23-2020 14:25   fbjni/detail/Hybrid.h
     1156  01-23-2020 14:25   fbjni/detail/Meta-forward.h
     4905  02-18-2021 11:31   fbjni/detail/MetaConvert.h
     5607  01-23-2020 14:25   fbjni/detail/TypeTraits.h
     9358  02-18-2021 11:31   fbjni/detail/Registration.h
    19170  02-18-2021 11:31   fbjni/detail/CoreClasses-inl.h
    17339  01-23-2020 14:25   fbjni/detail/Meta-inl.h
     4573  07-31-2020 15:56   fbjni/detail/Exceptions.h
     2783  01-23-2020 14:25   fbjni/detail/Boxed.h
     5420  07-31-2020 15:56   fbjni/detail/Environment.h
     2110  01-23-2020 14:25   fbjni/detail/References-forward.h
     3042  01-23-2020 14:25   fbjni/detail/Common.h
     6938  07-31-2020 15:56   fbjni/detail/Registration-inl.h
     2361  01-23-2020 14:25   fbjni/detail/Log.h
      802  07-31-2020 15:56   fbjni/detail/FbjniApi.h
    14670  02-18-2021 11:31   fbjni/detail/Meta.h
    23860  07-31-2020 15:56   fbjni/detail/CoreClasses.h
    15507  01-23-2020 14:25   fbjni/detail/References-inl.h
     1563  01-23-2020 14:25   fbjni/detail/JWeakReference.h
    10912  02-18-2021 11:31   fbjni/detail/SimpleFixedString.h
     4017  07-31-2020 15:56   fbjni/detail/ReferenceAllocators-inl.h
     4577  01-23-2020 14:25   fbjni/detail/Iterator.h
     6276  01-23-2020 14:25   fbjni/detail/Iterator-inl.h
     3049  01-23-2020 14:25   fbjni/detail/utf8.h
    22713  02-18-2021 11:31   fbjni/detail/References.h
     1954  01-23-2020 14:25   fbjni/detail/ReferenceAllocators.h
        0  02-18-2021 11:31   lyra/
     3092  01-23-2020 14:25   lyra/lyra_exceptions.h
     6684  01-23-2020 14:25   lyra/lyra.h
---------                     -------
   225910                     40 files

```
