### PR TITLE
[gradle] Don't create separate distribution for headers

### DIFF
--- a/gradle/android-tasks.gradle
+++ b/gradle/android-tasks.gradle
@@ -22,8 +22,11 @@ afterEvaluate { project ->
         }
     }
 
-    def gradlePublishing = extensions.getByType(PublishingExtension.class)
-    gradlePublishing.publications.create("headers", MavenPublication.class) {
-      artifact(headersJar)
+    publishing {
+        publications {
+            withType(MavenPublication).configureEach {
+                artifact(headersJar)
+            }
+        }
     }
 }


### PR DESCRIPTION
Summary:
dogscience

I'm just throwing code against the (gradle) wall and see what sticks.
The problem with the previous setup was that it created two
publications. While the outcome looked fine in general, it created
two POM files which overwrote each other and the latter one created
would not have all the meta data, causing Maven Central validation
to fail.

With this we're modifying the existing one(s) to add the headers JAR
instead.

Test Plan:
./gradlew installArchives

Checked my ~/.m2/ and now there's only one distribution, i.e. not
multiple installations and, importantly, only one POM file.
