### PR TITLE
Fix bug: package com.facebook.soloader.nativeloader does not exist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ android {
 
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    implementation 'com.facebook.soloader:nativeloader:0.10.1'
+    api 'com.facebook.soloader:nativeloader:0.10.1'
 }
 
 apply from: rootProject.file('gradle/release.gradle')


### PR DESCRIPTION
When loading jni libraries which used fbjni, such as writing like
this:
    System.loadLibrary("mylib");
there will be a crash said that
    NativeLoader has not been initialized.  To use standard native
    library loading, call NativeLoader.init(new SystemDelegate()).
Since NativeLoader is in package com.facebook.soloader:nativeloader,
which is hidden from the user, a user have to manually import this
module.

## Motivation

Why are you making this change?

## Summary

What did you change?

How does the code work?

Why did you choose this approach?

## Test Plan

How did you test this change?
Any change that adds functionality should add a unit test as well.
