### PR TITLE
Mark DestructorThread as a daemon

### DIFF
--- a/java/com/facebook/jni/DestructorThread.java
+++ b/java/com/facebook/jni/DestructorThread.java
@@ -90,6 +90,7 @@ public class DestructorThread {
           }
         };
 
+    sThread.setDaemon(true);
     sThread.start();
   }
 


### PR DESCRIPTION
Mark DestructorThread as a daemon so the JVM can exit.

## Motivation

Why are you making this change?
To fix #25 

## Summary

What did you change?
I added `sThread.setDaemon(true)`, which marks the destructor thread as a so called 'daemon' thread so it doesn't stop the JVM from exiting when all (other) user threads have terminated. 

How does the code work?
It marks the thread as a daemon (a opposed to user) thread. The JVM keeps running until all user threads exit. This thread never exits. 

Why did you choose this approach?
Because this is a textbook daemon thread. 

## Test Plan

How did you test this change?
See @dreiss code example in #25
