### PR TITLE
Install fbjniLibraryConfig.cmake at CMAKE_INSTALL_LIBDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ install(TARGETS fbjni EXPORT fbjniLibraryConfig
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}) #For windows
 
-install(EXPORT fbjniLibraryConfig DESTINATION share/cmake/fbjni
+install(EXPORT fbjniLibraryConfig DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/fbjni
   FILE fbjniLibraryConfig.cmake)
 
 if(MSVC)


### PR DESCRIPTION
It's pretty common for the lib directory to be added
to the cmake modules path, but much less so for
share. 

This is to better align with dominate cmake pratices.

## Motivation

Why are you making this change?

## Summary

What did you change?

How does the code work?

Why did you choose this approach?

## Test Plan

How did you test this change?
Any change that adds functionality should add a unit test as well.
