### PR TITLE
Bump SoLoader version to 0.10.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ android {
 
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    implementation 'com.facebook.soloader:nativeloader:0.10.4'
+    implementation 'com.facebook.soloader:nativeloader:0.10.5'
 }
 
 apply from: rootProject.file('gradle/release.gradle')

--- a/host.gradle
+++ b/host.gradle
@@ -34,7 +34,7 @@ sourceSets {
 
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    implementation 'com.facebook.soloader:nativeloader:0.10.4'
+    implementation 'com.facebook.soloader:nativeloader:0.10.5'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.easytesting:fest-assert-core:2.0M10'
     testImplementation 'org.mockito:mockito-core:2.28.2'


### PR DESCRIPTION
Summary: Use system linker by default on Android N and above devices.

Differential Revision: D43575298

