### PR TITLE
Add getMessage to JThrowable and getSimpleName to JClass

### DIFF
--- a/cxx/fbjni/detail/CoreClasses-inl.h
+++ b/cxx/fbjni/detail/CoreClasses-inl.h
@@ -304,6 +304,11 @@ inline void registerNatives(const char* name, std::initializer_list<JNINativeMet
   findClassLocal(name)->registerNatives(methods);
 }
 
+inline auto JClass::getSimpleName() -> local_ref<JString> {
+  static auto meth = javaClassStatic()->getMethod<JString::javaobject()>("getSimpleName");
+  return meth(self());
+}
+
 
 // jstring /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/cxx/fbjni/detail/CoreClasses.h
+++ b/cxx/fbjni/detail/CoreClasses.h
@@ -37,6 +37,7 @@ namespace jni {
 
 class JClass;
 class JObject;
+class JString;
 
 namespace detail {
 
@@ -329,6 +330,8 @@ class JClass : public JavaClass<JClass, JObject, jclass> {
   template<typename F>
   JNonvirtualMethod<F> getNonvirtualMethod(const char* name, const char* descriptor) const;
 
+  local_ref<JString> getSimpleName();
+
 private:
   jclass self() const noexcept;
 };
@@ -604,6 +607,7 @@ class JThrowable : public JavaClass<JThrowable, JObject, jthrowable> {
 
   local_ref<JThrowable> initCause(alias_ref<JThrowable> cause);
   local_ref<JStackTrace> getStackTrace();
+  local_ref<JString> getMessage();
   void setStackTrace(alias_ref<JArrayClass<JStackTraceElement::javaobject>>);
 };
 

--- a/cxx/fbjni/detail/Exceptions.cpp
+++ b/cxx/fbjni/detail/Exceptions.cpp
@@ -186,6 +186,11 @@ void JThrowable::setStackTrace(alias_ref<JStackTrace> stack) {
   return meth(self(), stack);
 }
 
+auto JThrowable::getMessage() -> local_ref<JString> {
+  static auto meth = javaClassStatic()->getMethod<JString::javaobject()>("getMessage");
+  return meth(self());
+}
+
 auto JStackTraceElement::create(
     const std::string& declaringClass, const std::string& methodName, const std::string& file, int line)
     -> local_ref<javaobject> {


### PR DESCRIPTION
## Motivation

Why are you making this change?

To enable RN to retrieve details about Throwables.

Relates to https://github.com/facebook/react-native/pull/36925. Where these changes will be used.

## Summary

What did you change?

Added `getMessage` to JThrowable.

Added `getSimpleName` to JClass.

How does the code work?

Uses dynamic Java method call like other similar methods.

## Test Plan

How did you test this change?

Could anyone guide me on how to test my changes of `fbjni` in RN?

I wanted to publish the package to my local Maven and add it to RN to verify the functionality, but it didn't work.

What I tried:

1. `./gradlew publishToMavenLocal` generated `0.3.1-SNAPSHOT`
2. Add `mavenLocal()` to `packages/rn-tester/android/app/build.gradle`.
3. yarn install-android-jsc

I got this error:
```
[CXX1429] error when building with cmake using /Users/krystofwoldrich/random/react-native/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt: C++ build system [prefab] failed while executing:
    "/Applications/Android Studio.app/Contents/jbr/Contents/Home/bin/java" \
      --class-path \
      /Users/krystofwoldrich/.gradle/caches/modules-2/files-2.1/com.google.prefab/cli/2.0.0/f2702b5ca13df54e3ca92f29d6b403fb6285d8df/cli-2.0.0-all.jar \
      com.google.prefab.cli.AppKt \
      --build-system \
      cmake \
      --platform \
      android \
      --abi \
      arm64-v8a \
      --os-version \
      21 \
      --stl \
      c++_shared \
      --ndk-version \
      23 \
      --output \
      /var/folders/tl/jddrmdy97gj0cljrcwb_qkzc0000gn/T/agp-prefab-staging13347947173282983619/staged-cli-output \
      /Users/krystofwoldrich/.gradle/caches/transforms-3/f866505a036566e921ad0564b1cacdd9/transformed/fbjni-0.3.1-SNAPSHOT/prefab \
      /Users/krystofwoldrich/random/react-native/packages/react-native/ReactAndroid/build/intermediates/cxx/refs/packages/react-native/ReactAndroid/hermes-engine/572y156m
  from /Users/krystofwoldrich/random/react-native/packages/react-native/ReactAndroid
Exception in thread "main" java.lang.IllegalArgumentException: version must be compatible with CMake, if present
	at com.google.prefab.api.Package.<init>(Package.kt:58)
	at com.google.prefab.cli.Cli$packages$2.invoke(Cli.kt:124)
	at com.google.prefab.cli.Cli$packages$2.invoke(Cli.kt:123)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at com.google.prefab.cli.Cli.getPackages(Cli.kt:123)
	at com.google.prefab.cli.Cli.validate(Cli.kt:172)
	at com.google.prefab.cli.Cli.run(Cli.kt:189)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:204)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:17)
	at com.github.ajalt.clikt.core.CliktCommand.parse(CliktCommand.kt:396)
	at com.github.ajalt.clikt.core.CliktCommand.parse$default(CliktCommand.kt:393)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:411)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:436)
	at com.google.prefab.cli.AppKt.main(App.kt:28)
```

Any change that adds functionality should add a unit test as well.
