### PR TITLE
Bump CMake to 3.18.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ android {
             cmake {
                 arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_shared'
                 targets 'fbjni'
-                version '3.10.2.4988404'
+                version '3.18.1'
             }
         }
 

--- a/scripts/run-host-tests.sh
+++ b/scripts/run-host-tests.sh
@@ -16,7 +16,7 @@
 set -exo pipefail
 
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
-CMAKE=$ANDROID_HOME/cmake/3.10.2.4988404/bin/cmake
+CMAKE=$ANDROID_HOME/cmake/3.18.1/bin/cmake
 export CXX=clang++
 
 mkdir -p "$BASE_DIR/host-build-cmake"


### PR DESCRIPTION
## Motivation

CI is currently red due to a wrong CMake version. I'm bumping it to the next stable one included in the NDK

## Test Plan

Will wait for green CI signal