### PR TITLE
Bump to NDK 26

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id 'com.android.library' version '8.0.2'
+    id 'com.android.library' version '8.1.2'
     id 'maven-publish'
     id 'com.vanniktech.maven.publish' version '0.25.3'
 }
@@ -26,8 +26,8 @@ repositories {
 }
 
 android {
-    compileSdk 33
-    ndkVersion '25.1.8937393'
+    compileSdk 34
+    ndkVersion '26.0.10792818'
 
     externalNativeBuild {
         cmake {
@@ -37,7 +37,7 @@ android {
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 33
+        targetSdkVersion 34
         buildConfigField "boolean", "IS_INTERNAL_BUILD", 'true'
         namespace "com.facebook.fbjni"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Summary:
This bumps fbjni to NDK 26, the latest stable NDK, lining up with RN 0.74 compatibility.

Google [documents](https://developer.android.com/ndk/guides/middleware-vendors#choosing_api_levels_and_ndk_versions) the expected NDK to NDK compatibility:

> NDK versions are largely compatible with each other, but occasionally there are changes that break compatibility. If you know that all of your users are using the same version of the NDK, it's best to use the same version that they do. Otherwise, use the newest version.

Differential Revision: D50296514


