### PR TITLE
Bump Gradle minSdk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 21
         targetSdkVersion 34
         buildConfigField "boolean", "IS_INTERNAL_BUILD", 'true'
         namespace "com.facebook.fbjni"

--- a/cxx/fbjni/detail/utf8.h
+++ b/cxx/fbjni/detail/utf8.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include <jni.h>


### PR DESCRIPTION
Summary:
https://github.com/facebookincubator/fbjni/commit/bd94aae8f47ffa012783b94bf53379f0db84f725 bumped to NDK 26 (latest LTS NDK).

NDK 26 [dropped](https://github.com/android/ndk/wiki/Changelog-r26) [support](https://github.com/android/ndk/issues/1751) for KitKat, and NDK 25 already required minSDK 19, so our minSdk of 15 is too low.

This bumps the minSdk, so that when we publish AARs for next fbjni published version, it errors if user is on earlier SDK.

Differential Revision: D51146044


