### PR TITLE
feat: Add `bigEndian()` and `littleEndian()` fields to `JByteOrder`

### DIFF
--- a/cxx/fbjni/ByteBuffer.cpp
+++ b/cxx/fbjni/ByteBuffer.cpp
@@ -69,6 +69,18 @@ local_ref<JByteOrder> JByteOrder::nativeOrder() {
   return meth(JByteOrder::javaClassStatic());
 }
 
+local_ref<JByteOrder> JByteOrder::bigEndian() {
+  static auto field =
+      JByteOrder::javaClassStatic()->getStaticField<JByteOrder>("BIG_ENDIAN");
+  return JByteOrder::javaClassStatic()->getStaticFieldValue(field);
+}
+
+local_ref<JByteOrder> JByteOrder::littleEndian() {
+  static auto field =
+      JByteOrder::javaClassStatic()->getStaticField<JByteOrder>("LITTLE_ENDIAN");
+  return JByteOrder::javaClassStatic()->getStaticFieldValue(field);
+}
+
 local_ref<JByteBuffer> JByteBuffer::wrapBytes(uint8_t* data, size_t size) {
   // env->NewDirectByteBuffer requires that size is positive. Android's
   // dalvik returns an invalid result and Android's art aborts if size == 0.

--- a/cxx/fbjni/ByteBuffer.h
+++ b/cxx/fbjni/ByteBuffer.h
@@ -36,6 +36,8 @@ class JByteOrder : public JavaClass<JByteOrder> {
   constexpr static const char* kJavaDescriptor = "Ljava/nio/ByteOrder;";
 
   static local_ref<JByteOrder> nativeOrder();
+  static local_ref<JByteOrder> bigEndian();
+  static local_ref<JByteOrder> littleEndian();
 };
 
 // JNI's NIO support has some awkward preconditions and error reporting. This


### PR DESCRIPTION
## Motivation

`JByteBuffer`s could only be initialized with `nativeOrder` endianness.
With this PR, both `littleEndian()` and `bigEndian()` fields are exposed in `JByteOrder` and can now be set through `JByteBuffer::order(...)`.

## Summary

Get static fields `LITTLE_ENDIAN` and `BIG_ENDIAN` through `JByteOrder`.

## Test Plan

Test code:

Default:

```cpp
auto buffer = JByteBuffer::allocateDirect(5);
uint8_t* data = buffer->getDirectData();
data[0] = 255;
data[1] = 1;
__android_log_print(ANDROID_LOG_INFO, "Test", "First item: %i", data[0]);
```

With custom Endian:

```cpp
auto buffer = JByteBuffer::allocateDirect(5);
buffer->order(JByteOrder::bigEndian()); // <-- or littleEndian()
uint8_t* data = buffer->getDirectData();
data[0] = 255;
data[1] = 1;
__android_log_print(ANDROID_LOG_INFO, "Test", "First item: %i", data[0]);
```