### PR TITLE
feat: Bump Android NDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ repositories {
 
 android {
     compileSdk 34
-    ndkVersion '26.0.10792818'
+    ndkVersion '26.1.10909125'
 
     externalNativeBuild {
         cmake {


### PR DESCRIPTION
## Motivation

Bumps Android NDK version to 26.1.xxx - see https://github.com/facebook/react-native/pull/42656, cc @cortinico 

## Summary

bump in gradle

## Test Plan

build app