### PR TITLE
Migrate google java format from 1.7 -> 1.19.2

### DIFF
--- a/java/com/facebook/jni/DestructorThread.java
+++ b/java/com/facebook/jni/DestructorThread.java
@@ -57,6 +57,7 @@ public class DestructorThread {
 
   /** A list to keep all active Destructors in memory confined to the Destructor thread. */
   private static final DestructorList sDestructorList;
+
   /** A thread safe stack where new Destructors are placed before being add to sDestructorList. */
   private static final DestructorStack sDestructorStack;
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/SoLoader/pull/122

This diff migrates google java format form 1.7 to 1.19.2. This update will allow for new language features from java 17 and 21. This diff also formats all necessary files.

 Changelog:
    [Internal][Changed] - Updated format from google-java-format 1.7 -> 1.19.2

Reviewed By: IanChilds

Differential Revision: D52786052


