### PR TITLE
NDK 27 & Support 16kb page size for Android15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ repositories {
 
 android {
     compileSdk 34
-    ndkVersion '26.1.10909125'
+    ndkVersion '27.1.12297006'
 
     externalNativeBuild {
         cmake {
@@ -53,7 +53,7 @@ android {
 
         externalNativeBuild {
             cmake {
-                arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_shared'
+                arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_shared', '-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON'
                 targets 'fbjni'
                 version '3.22.1'
             }


### PR DESCRIPTION
## Motivation

https://github.com/facebookincubator/fbjni/issues/97

## Summary

Updated ndk to 27, enabled flexible page size support

https://developer.android.com/guide/practices/page-sizes#compile-r27-higher

## Test Plan

Built locally and checked alignment via test method [here](https://developer.android.com/guide/practices/page-sizes#test) as well as `objdump` on the binary
