### PR TITLE
Prepare version 0.7.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 # in the root directory of this source tree.
 
 # POM publishing constants
-VERSION_NAME=0.6.1-SNAPSHOT
+VERSION_NAME=0.7.0
 GROUP=com.facebook.fbjni
 SONATYPE_STAGING_PROFILE=comfacebook
 SONATYPE_HOST=DEFAULT


### PR DESCRIPTION
Summary: This just bumps the version of fbjni ahead of a new public release.

Differential Revision: D63264478
