### PR TITLE
Add `com.facebook.infer.annotation:infer-annotation` to unblock CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ android {
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'com.facebook.soloader:nativeloader:0.10.5'
-    implementation 'com.facebook.infer.annotation:infer-annotation:0.18.0'
+    compileOnly 'com.facebook.infer.annotation:infer-annotation:0.18.0'
 }
 
 task headersJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ android {
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'com.facebook.soloader:nativeloader:0.10.5'
+    implementation 'com.facebook.infer.annotation:infer-annotation:0.18.0'
 }
 
 task headersJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -80,8 +80,10 @@ android {
 
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    implementation 'com.facebook.soloader:nativeloader:0.10.5'
     compileOnly 'com.facebook.infer.annotation:infer-annotation:0.18.0'
+    testCompileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+    testCompileOnly 'com.facebook.infer.annotation:infer-annotation:0.18.0'
+    implementation 'com.facebook.soloader:nativeloader:0.10.5'
 }
 
 task headersJar(type: Jar) {

--- a/host.gradle
+++ b/host.gradle
@@ -36,6 +36,7 @@ sourceSets {
 dependencies {
     implementation 'com.facebook.soloader:nativeloader:0.10.5'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
+    implementation 'com.facebook.infer.annotation:infer-annotation:0.18.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.assertj:assertj-core:2.9.0'
     testImplementation 'org.mockito:mockito-core:2.28.2'


### PR DESCRIPTION
## Motivation

CI is currently red, this should unblock it.

## Summary

Added

```
com.facebook.infer.annotation:infer-annotation:0.18.0
```

to the dependencies so the `@Nullsafe` annotation can actually be resolved.

## Test Plan

CI