### PR TITLE
Bump to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include(GNUInstallDirs)
 
 set(FBJNI_COMPILE_OPTIONS
   -Wall
-  -std=c++17
+  -std=c++20
   -pthread
   -fno-omit-frame-pointer
   -fexceptions


### PR DESCRIPTION
Summary: This aligns to the same version we use for React Native.

Differential Revision: D76807229
