### PR TITLE
Add <exception> to  SimpleFixedString.h

### DIFF
--- a/cxx/fbjni/detail/SimpleFixedString.h
+++ b/cxx/fbjni/detail/SimpleFixedString.h
@@ -20,6 +20,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <exception>
 #include <stdexcept>
 #include <string>
 #include <utility>


### PR DESCRIPTION
This code fails to compile in C++23 due to the missing header (see line 96).
